### PR TITLE
feat: replace confirm with streaming dialog

### DIFF
--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -55,7 +55,13 @@ export default function App() {
   const { isConnected } = useAccount();
   const [selectedVideo, setSelectedVideo] = useState<Video | null>(null);
   return (
-    <YStack flex={1} padding="$4" alignItems="center" justifyContent="center">
+    <YStack
+      flex={1}
+      padding="$4"
+      alignItems="center"
+      justifyContent="center"
+      width={1200}
+    >
       {isConnected ? (
         selectedVideo ? (
           <VideoPage

--- a/apps/demo-od-streaming/src/VideoPlayer.tsx
+++ b/apps/demo-od-streaming/src/VideoPlayer.tsx
@@ -5,11 +5,9 @@ import { useAccount, usePublicClient, useWriteContract } from "wagmi";
 import videojs from "video.js";
 import "video.js/dist/video-js.css";
 
-const CFA_FORWARDER =
-  "0xcfA132E353cB4E398080B9700609bb008eceB125" as const;
-const GS_DEV_TOKEN =
-  "0xFa51eFDc0910CCdA91732e6806912Fa12e2FD475" as const;
-const RECEIVER = "0x0000000000000000000000000000000000000001" as const;
+const CFA_FORWARDER = "0xcfA132E353cB4E398080B9700609bb008eceB125" as const;
+const GS_DEV_TOKEN = "0xFa51eFDc0910CCdA91732e6806912Fa12e2FD475" as const;
+const RECEIVER = import.meta.env.VITE_STREAM_RECEIVER;
 
 const cfaForwarderAbi = [
   {
@@ -40,6 +38,7 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
   const { address } = useAccount();
   const publicClient = usePublicClient();
   const { writeContractAsync } = useWriteContract();
+  const [transactionInProgress, setTransactionInProgress] = useState(false);
 
   const confirmedRef = useRef(false);
 
@@ -103,13 +102,7 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
       address: CFA_FORWARDER,
       abi: cfaForwarderAbi,
       functionName: "createFlow",
-      args: [
-        GS_DEV_TOKEN,
-        address,
-        RECEIVER,
-        flowRate,
-        "0x" as `0x${string}`,
-      ],
+      args: [GS_DEV_TOKEN, address, RECEIVER, flowRate, "0x" as `0x${string}`],
     });
 
     await publicClient.waitForTransactionReceipt({ hash });
@@ -118,10 +111,15 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
   const handleConfirm = async () => {
     const player = playerRef.current;
     if (!player) return;
-    await createFlow(flowRateWei);
-    confirmedRef.current = true;
-    setDialogOpen(false);
-    player.play();
+    setTransactionInProgress(true);
+    try {
+      await createFlow(flowRateWei);
+      confirmedRef.current = true;
+      setDialogOpen(false);
+      player.play();
+    } finally {
+      setTransactionInProgress(false);
+    }
   };
 
   return (
@@ -141,14 +139,14 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           Loading video player...
         </div>
       ) : (
-        <div data-vjs-player style={{ width: "100%", height: 300 }}>
+        <div data-vjs-player style={{ width: "100%", objectFit: "cover" }}>
           <video
             ref={videoRef}
-            className="video-js vjs-big-play-centered"
+            className="video-js vjs-big-play-centered vjs-responsive"
             controls
             preload="auto"
             playsInline
-            style={{ width: "100%", height: "300px", backgroundColor: "#000" }}
+            style={{ width: "100%", height: "100%", backgroundColor: "#000" }}
           >
             <source src={src} type="video/mp4" />
           </video>
@@ -166,18 +164,30 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
             width="90%"
             maxWidth={400}
           >
-            <Dialog.Title>Start Streaming</Dialog.Title>
+            <Dialog.Title>
+              {transactionInProgress
+                ? "Processing Transaction"
+                : "Start Streaming"}
+            </Dialog.Title>
             <YStack gap="$2">
-              <Text>Video length: {Math.round(duration)} sec</Text>
-              <Text>
-                Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec ({flowRateWei.toString()} wei/sec)
-              </Text>
-              <Text>Total: {totalTokens.toFixed(2)} G$</Text>
+              {transactionInProgress ? (
+                <Text>
+                  Please wait while the transaction is being processed...
+                </Text>
+              ) : (
+                <>
+                  <Text>Video length: {Math.round(duration)} sec</Text>
+                  <Text>Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec</Text>
+                  <Text>Total: {totalTokens.toFixed(2)} G$</Text>
+                </>
+              )}
             </YStack>
-            <XStack gap="$3" justifyContent="flex-end" marginTop="$2">
-              <Button onPress={() => setDialogOpen(false)}>Cancel</Button>
-              <Button onPress={handleConfirm}>Start</Button>
-            </XStack>
+            {!transactionInProgress && (
+              <XStack gap="$3" justifyContent="flex-end" marginTop="$2">
+                <Button onPress={() => setDialogOpen(false)}>Cancel</Button>
+                <Button onPress={handleConfirm}>Start</Button>
+              </XStack>
+            )}
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog>

--- a/apps/demo-od-streaming/src/VideoPlayer.tsx
+++ b/apps/demo-od-streaming/src/VideoPlayer.tsx
@@ -1,6 +1,31 @@
 import { useEffect, useRef, useState } from "react";
+import { Button, Dialog, Text, XStack, YStack } from "tamagui";
+import { parseEther } from "viem";
+import { useAccount, usePublicClient, useWriteContract } from "wagmi";
 import videojs from "video.js";
 import "video.js/dist/video-js.css";
+
+const CFA_FORWARDER =
+  "0xcfA132E353cB4E398080B9700609bb008eceB125" as const;
+const GS_DEV_TOKEN =
+  "0xFa51eFDc0910CCdA91732e6806912Fa12e2FD475" as const;
+const RECEIVER = "0x0000000000000000000000000000000000000001" as const;
+
+const cfaForwarderAbi = [
+  {
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "flowrate", type: "int96" },
+      { name: "userData", type: "bytes" },
+    ],
+    name: "createFlow",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
 
 export type VideoPlayerProps = {
   src: string;
@@ -10,6 +35,18 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const playerRef = useRef<any>(null);
   const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const { address } = useAccount();
+  const publicClient = usePublicClient();
+  const { writeContractAsync } = useWriteContract();
+
+  const confirmedRef = useRef(false);
+
+  const TOKENS_PER_SECOND = 0.2 / 180 / 0.00011; // ~10.1 G$/sec
+  const flowRateWei = parseEther(TOKENS_PER_SECOND.toFixed(3));
+
+  const totalTokens = duration * TOKENS_PER_SECOND;
 
   useEffect(() => {
     setTimeout(() => {
@@ -38,33 +75,54 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
       player.controls(true); // Ensure controls are enabled
     });
 
-    let confirmed = false;
-
     const handlePlay = () => {
       console.log("play event triggered");
-      if (!confirmed) {
+      if (!confirmedRef.current) {
         player.pause();
-        player.trigger("sfPlayRequest");
+        setDialogOpen(true);
       }
     };
 
-    const handleRequest = () => {
-      if (window.confirm("Start playing the video?")) {
-        confirmed = true;
-        player.play();
-      }
-    };
+    player.on("loadedmetadata", () => {
+      setDuration(player.duration());
+    });
 
     player.on("play", handlePlay);
-    player.on("sfPlayRequest", handleRequest);
 
     // Ensure player is properly disposed
     return () => {
       player.off("play", handlePlay);
-      player.off("sfPlayRequest", handleRequest);
       player.dispose();
     };
   }, [src, loading]);
+
+  const createFlow = async (flowRate: bigint) => {
+    if (!address || !publicClient) return;
+
+    const hash = await writeContractAsync({
+      address: CFA_FORWARDER,
+      abi: cfaForwarderAbi,
+      functionName: "createFlow",
+      args: [
+        GS_DEV_TOKEN,
+        address,
+        RECEIVER,
+        flowRate,
+        "0x" as `0x${string}`,
+      ],
+    });
+
+    await publicClient.waitForTransactionReceipt({ hash });
+  };
+
+  const handleConfirm = async () => {
+    const player = playerRef.current;
+    if (!player) return;
+    await createFlow(flowRateWei);
+    confirmedRef.current = true;
+    setDialogOpen(false);
+    player.play();
+  };
 
   return (
     <div style={{ width: "100%" }}>
@@ -96,6 +154,33 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           </video>
         </div>
       )}
+
+      <Dialog modal open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay />
+          <Dialog.Content
+            bordered
+            elevate
+            padding="$4"
+            gap="$3"
+            width="90%"
+            maxWidth={400}
+          >
+            <Dialog.Title>Start Streaming</Dialog.Title>
+            <YStack gap="$2">
+              <Text>Video length: {Math.round(duration)} sec</Text>
+              <Text>
+                Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec ({flowRateWei.toString()} wei/sec)
+              </Text>
+              <Text>Total: {totalTokens.toFixed(2)} G$</Text>
+            </YStack>
+            <XStack gap="$3" justifyContent="flex-end" marginTop="$2">
+              <Button onPress={() => setDialogOpen(false)}>Cancel</Button>
+              <Button onPress={handleConfirm}>Start</Button>
+            </XStack>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
     </div>
   );
 }

--- a/apps/demo-od-streaming/tsconfig.json
+++ b/apps/demo-od-streaming/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "ES2022",
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "dist",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   }
 }


### PR DESCRIPTION
## Summary
- replace `window.confirm` with Tamagui dialog before playback
- display GoodDollar streaming cost and calculate flow rate
- request wallet signature to start a Superfluid stream before playing

## Testing
- `pnpm i`
- `pnpm -w turbo run build` *(fails: subscription-sdk build command exited with 1)*
- `pnpm -w turbo run lint`
- `pnpm -w turbo run typecheck` *(fails: subscription-sdk typecheck command exited with 1)*

------
https://chatgpt.com/codex/tasks/task_b_68ac04a198c88329b82077d85f6e598e