### PR TITLE
feat: add global dark neon Tamagui theme

### DIFF
--- a/apps/demo-od-streaming/index.html
+++ b/apps/demo-od-streaming/index.html
@@ -8,7 +8,7 @@
       rel="stylesheet"
     />
   </head>
-  <body style="background-color:#0d0d0d;">
+  <body style="background-color:#0d0d0d;color:#e0e0e0;font-family:'Orbitron',sans-serif;">
     <div id="root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/apps/demo-od-streaming/index.html
+++ b/apps/demo-od-streaming/index.html
@@ -3,8 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <title>On-Demand Streaming Demo</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body>
+  <body style="background-color:#0d0d0d;">
     <div id="root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/apps/demo-od-streaming/package.json
+++ b/apps/demo-od-streaming/package.json
@@ -11,14 +11,15 @@
   "dependencies": {
     "@reown/appkit": "1.7.20",
     "@tamagui/animations-react-native": "1.132.21",
+    "@tamagui/theme-builder": "^1.132.21",
     "@tamagui/themes": "1.132.21",
     "@tanstack/react-query": "5.85.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native-web": "^0.21.1",
     "tamagui": "1.132.21",
+    "video.js": "8.23.4",
     "viem": "2.35.1",
-    "wagmi": "2.16.5",
-    "video.js": "8.23.4"
+    "wagmi": "2.16.5"
   }
 }

--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -4,22 +4,20 @@ import { mockVideos, Video } from "./videos";
 import { VideoPlayer } from "./VideoPlayer";
 import { useState } from "react";
 
-const GS_DEV_TOKEN = "0xFa51eFDc0910CCdA91732e6806912Fa12e2FD475";
-
 function renderVideo(video: Video, onSelect: (v: Video) => void) {
   return (
     <Button
       key={video.id}
       onPress={() => onSelect(video)}
       borderRadius="$6"
-      padding={0}
+      padding={10}
       overflow="hidden"
+      height="100px"
       borderWidth={2}
       borderColor="$borderColor"
-      elevate
-      animation="fast"
-      hoverStyle={{ backgroundColor: '$backgroundHover' }}
-      pressStyle={{ backgroundColor: '$backgroundPress' }}
+      // animation="fast"
+      hoverStyle={{ backgroundColor: "$backgroundHover" }}
+      pressStyle={{ backgroundColor: "$backgroundPress" }}
     >
       <Image source={{ uri: video.thumbnail }} width={160} height={90} />
     </Button>
@@ -32,7 +30,8 @@ function ConnectSection() {
       gap="$4"
       alignItems="center"
       justifyContent="center"
-      animation="medium"
+      theme="dark_neon"
+      // animation="medium"
     >
       <Text color="$color">Connect your wallet to view videos</Text>
       {/* AppKit provides the connect button as a web component */}
@@ -43,7 +42,12 @@ function ConnectSection() {
 
 function VideoGallery({ onSelect }: { onSelect: (v: Video) => void }) {
   return (
-    <XStack flexWrap="wrap" gap="$4" animation="medium">
+    <XStack
+      flexWrap="wrap"
+      gap="$4"
+
+      // animation="medium"
+    >
       {mockVideos.map((v) => renderVideo(v, onSelect))}
     </XStack>
   );
@@ -58,14 +62,14 @@ function VideoPage({ video, onBack }: { video: Video; onBack: () => void }) {
         borderRadius="$6"
         borderWidth={2}
         borderColor="$borderColor"
-        elevate
-        animation="fast"
-        hoverStyle={{ backgroundColor: '$backgroundHover' }}
-        pressStyle={{ backgroundColor: '$backgroundPress' }}
+        elevation={"$1"}
+        // animation="fast"
+        hoverStyle={{ backgroundColor: "$backgroundHover" }}
+        pressStyle={{ backgroundColor: "$backgroundPress" }}
       >
         <Text color="$color">Back</Text>
       </Button>
-      </YStack>
+    </YStack>
   );
 }
 

--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -34,7 +34,7 @@ function ConnectSection() {
       justifyContent="center"
       animation="medium"
     >
-      <Text>Connect your wallet to view videos</Text>
+      <Text color="$color">Connect your wallet to view videos</Text>
       {/* AppKit provides the connect button as a web component */}
       <appkit-button />
     </YStack>
@@ -56,12 +56,14 @@ function VideoPage({ video, onBack }: { video: Video; onBack: () => void }) {
       <Button
         onPress={onBack}
         borderRadius="$6"
+        borderWidth={2}
+        borderColor="$borderColor"
         elevate
         animation="fast"
         hoverStyle={{ backgroundColor: '$backgroundHover' }}
         pressStyle={{ backgroundColor: '$backgroundPress' }}
       >
-        Back
+        <Text color="$color">Back</Text>
       </Button>
       </YStack>
   );

--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -8,13 +8,20 @@ const GS_DEV_TOKEN = "0xFa51eFDc0910CCdA91732e6806912Fa12e2FD475";
 
 function renderVideo(video: Video, onSelect: (v: Video) => void) {
   return (
-    <Button key={video.id} onPress={() => onSelect(video)} unstyled>
-      <Image
-        source={{ uri: video.thumbnail }}
-        width={160}
-        height={90}
-        borderRadius={8}
-      />
+    <Button
+      key={video.id}
+      onPress={() => onSelect(video)}
+      borderRadius="$6"
+      padding={0}
+      overflow="hidden"
+      borderWidth={2}
+      borderColor="$borderColor"
+      elevate
+      animation="fast"
+      hoverStyle={{ backgroundColor: '$backgroundHover' }}
+      pressStyle={{ backgroundColor: '$backgroundPress' }}
+    >
+      <Image source={{ uri: video.thumbnail }} width={160} height={90} />
     </Button>
   );
 }
@@ -46,8 +53,17 @@ function VideoPage({ video, onBack }: { video: Video; onBack: () => void }) {
   return (
     <YStack gap="$4" alignItems="center" width="100%">
       <VideoPlayer src={video.src} />
-      <Button onPress={onBack}>Back</Button>
-    </YStack>
+      <Button
+        onPress={onBack}
+        borderRadius="$6"
+        elevate
+        animation="fast"
+        hoverStyle={{ backgroundColor: '$backgroundHover' }}
+        pressStyle={{ backgroundColor: '$backgroundPress' }}
+      >
+        Back
+      </Button>
+      </YStack>
   );
 }
 

--- a/apps/demo-od-streaming/src/VideoPlayer.tsx
+++ b/apps/demo-od-streaming/src/VideoPlayer.tsx
@@ -132,12 +132,24 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           alignItems="center"
           justifyContent="center"
           borderRadius="$6"
-          elevation="$1"
+          borderWidth={2}
+          borderColor="$borderColor"
+          elevation="$2"
+          shadowColor="$shadowColor"
         >
-          <Text>Loading video player...</Text>
+          <Text color="$color">Loading video player...</Text>
         </YStack>
       ) : (
-        <YStack data-vjs-player width="100%" overflow="hidden" borderRadius="$6">
+        <YStack
+          data-vjs-player
+          width="100%"
+          overflow="hidden"
+          borderRadius="$6"
+          borderWidth={2}
+          borderColor="$borderColor"
+          elevation="$2"
+          shadowColor="$shadowColor"
+        >
           <video
             ref={videoRef}
             className="video-js vjs-big-play-centered vjs-responsive"
@@ -158,26 +170,30 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
             bordered
             elevate
             borderRadius="$6"
+            backgroundColor="$background"
+            borderWidth={2}
+            borderColor="$borderColor"
+            shadowColor="$shadowColor"
             padding="$4"
             gap="$3"
             width="90%"
             maxWidth={400}
           >
-            <Dialog.Title>
+            <Dialog.Title color="$borderColor">
               {transactionInProgress
                 ? "Processing Transaction"
                 : "Start Streaming"}
             </Dialog.Title>
             <YStack gap="$2">
               {transactionInProgress ? (
-                <Text>
+                <Text color="$color">
                   Please wait while the transaction is being processed...
                 </Text>
               ) : (
                 <>
-                  <Text>Video length: {Math.round(duration)} sec</Text>
-                  <Text>Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec</Text>
-                  <Text>Total: {totalTokens.toFixed(2)} G$</Text>
+                  <Text color="$color">Video length: {Math.round(duration)} sec</Text>
+                  <Text color="$color">Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec</Text>
+                  <Text color="$color">Total: {totalTokens.toFixed(2)} G$</Text>
                 </>
               )}
             </YStack>
@@ -186,7 +202,10 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
                 <Button
                   onPress={() => setDialogOpen(false)}
                   borderRadius="$6"
-                  elevate
+                  borderWidth={2}
+                  borderColor="$borderColor"
+                  color="$color"
+                  elevation="$2"
                   animation="fast"
                   hoverStyle={{ backgroundColor: '$backgroundHover' }}
                   pressStyle={{ backgroundColor: '$backgroundPress' }}
@@ -196,10 +215,14 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
                 <Button
                   onPress={handleConfirm}
                   borderRadius="$6"
-                  elevate
+                  borderWidth={2}
+                  borderColor="$borderColor"
+                  backgroundColor="$borderColor"
+                  color="$background"
+                  elevation="$2"
                   animation="fast"
-                  hoverStyle={{ backgroundColor: '$backgroundHover' }}
-                  pressStyle={{ backgroundColor: '$backgroundPress' }}
+                  hoverStyle={{ backgroundColor: '$borderColorHover' }}
+                  pressStyle={{ backgroundColor: '$borderColorHover' }}
                 >
                   Start
                 </Button>

--- a/apps/demo-od-streaming/src/VideoPlayer.tsx
+++ b/apps/demo-od-streaming/src/VideoPlayer.tsx
@@ -134,7 +134,7 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           borderRadius="$6"
           borderWidth={2}
           borderColor="$borderColor"
-          elevation="$2"
+          elevation="$1"
           shadowColor="$shadowColor"
         >
           <Text color="$color">Loading video player...</Text>
@@ -147,7 +147,7 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           borderRadius="$6"
           borderWidth={2}
           borderColor="$borderColor"
-          elevation="$2"
+          elevation="$1"
           shadowColor="$shadowColor"
         >
           <video
@@ -156,7 +156,7 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
             controls
             preload="auto"
             playsInline
-            style={{ width: '100%', height: '100%' }}
+            style={{ width: "100%", height: "100%" }}
           >
             <source src={src} type="video/mp4" />
           </video>
@@ -168,12 +168,12 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
           <Dialog.Overlay backgroundColor="$background" opacity={0.8} />
           <Dialog.Content
             bordered
-            elevate
             borderRadius="$6"
             backgroundColor="$background"
             borderWidth={2}
             borderColor="$borderColor"
             shadowColor="$shadowColor"
+            elevation="$1"
             padding="$4"
             gap="$3"
             width="90%"
@@ -191,8 +191,12 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
                 </Text>
               ) : (
                 <>
-                  <Text color="$color">Video length: {Math.round(duration)} sec</Text>
-                  <Text color="$color">Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec</Text>
+                  <Text color="$color">
+                    Video length: {Math.round(duration)} sec
+                  </Text>
+                  <Text color="$color">
+                    Rate: {TOKENS_PER_SECOND.toFixed(2)} G$/sec
+                  </Text>
                   <Text color="$color">Total: {totalTokens.toFixed(2)} G$</Text>
                 </>
               )}
@@ -205,10 +209,10 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
                   borderWidth={2}
                   borderColor="$borderColor"
                   color="$color"
-                  elevation="$2"
-                  animation="fast"
-                  hoverStyle={{ backgroundColor: '$backgroundHover' }}
-                  pressStyle={{ backgroundColor: '$backgroundPress' }}
+                  // elevation="$1"
+                  // animation="fast"
+                  hoverStyle={{ backgroundColor: "$backgroundHover" }}
+                  pressStyle={{ backgroundColor: "$backgroundPress" }}
                 >
                   Cancel
                 </Button>
@@ -219,10 +223,10 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
                   borderColor="$borderColor"
                   backgroundColor="$borderColor"
                   color="$background"
-                  elevation="$2"
-                  animation="fast"
-                  hoverStyle={{ backgroundColor: '$borderColorHover' }}
-                  pressStyle={{ backgroundColor: '$borderColorHover' }}
+                  // elevation="$1"
+                  // animation="fast"
+                  hoverStyle={{ backgroundColor: "$borderColorHover" }}
+                  pressStyle={{ backgroundColor: "$borderColorHover" }}
                 >
                   Start
                 </Button>

--- a/apps/demo-od-streaming/src/VideoPlayer.tsx
+++ b/apps/demo-od-streaming/src/VideoPlayer.tsx
@@ -123,42 +123,41 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
   };
 
   return (
-    <div style={{ width: "100%" }}>
+    <YStack width="100%">
       {loading ? (
-        <div
-          style={{
-            width: "100%",
-            height: 300,
-            backgroundColor: "#000",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: "#fff",
-          }}
+        <YStack
+          width="100%"
+          height={300}
+          backgroundColor="$background"
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="$6"
+          elevation="$1"
         >
-          Loading video player...
-        </div>
+          <Text>Loading video player...</Text>
+        </YStack>
       ) : (
-        <div data-vjs-player style={{ width: "100%", objectFit: "cover" }}>
+        <YStack data-vjs-player width="100%" overflow="hidden" borderRadius="$6">
           <video
             ref={videoRef}
             className="video-js vjs-big-play-centered vjs-responsive"
             controls
             preload="auto"
             playsInline
-            style={{ width: "100%", height: "100%", backgroundColor: "#000" }}
+            style={{ width: '100%', height: '100%' }}
           >
             <source src={src} type="video/mp4" />
           </video>
-        </div>
+        </YStack>
       )}
 
       <Dialog modal open={dialogOpen} onOpenChange={setDialogOpen}>
         <Dialog.Portal>
-          <Dialog.Overlay />
+          <Dialog.Overlay backgroundColor="$background" opacity={0.8} />
           <Dialog.Content
             bordered
             elevate
+            borderRadius="$6"
             padding="$4"
             gap="$3"
             width="90%"
@@ -184,13 +183,31 @@ export function VideoPlayer({ src }: VideoPlayerProps) {
             </YStack>
             {!transactionInProgress && (
               <XStack gap="$3" justifyContent="flex-end" marginTop="$2">
-                <Button onPress={() => setDialogOpen(false)}>Cancel</Button>
-                <Button onPress={handleConfirm}>Start</Button>
+                <Button
+                  onPress={() => setDialogOpen(false)}
+                  borderRadius="$6"
+                  elevate
+                  animation="fast"
+                  hoverStyle={{ backgroundColor: '$backgroundHover' }}
+                  pressStyle={{ backgroundColor: '$backgroundPress' }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onPress={handleConfirm}
+                  borderRadius="$6"
+                  elevate
+                  animation="fast"
+                  hoverStyle={{ backgroundColor: '$backgroundHover' }}
+                  pressStyle={{ backgroundColor: '$backgroundPress' }}
+                >
+                  Start
+                </Button>
               </XStack>
             )}
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog>
-    </div>
+    </YStack>
   );
 }

--- a/apps/demo-od-streaming/src/main.tsx
+++ b/apps/demo-od-streaming/src/main.tsx
@@ -51,13 +51,13 @@ const rootEl = document.getElementById("root");
 if (rootEl) {
   createRoot(rootEl).render(
     <StrictMode>
-      <WagmiProvider config={wagmiAdapter.wagmiConfig}>
-        <QueryClientProvider client={queryClient}>
-          <TamaguiProvider config={config} defaultTheme="dark_neon">
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <WagmiProvider config={wagmiAdapter.wagmiConfig}>
+          <QueryClientProvider client={queryClient}>
             <App />
-          </TamaguiProvider>
-        </QueryClientProvider>
-      </WagmiProvider>
+          </QueryClientProvider>
+        </WagmiProvider>
+      </TamaguiProvider>
     </StrictMode>
   );
 }

--- a/apps/demo-od-streaming/src/main.tsx
+++ b/apps/demo-od-streaming/src/main.tsx
@@ -36,7 +36,7 @@ createAppKit({
   features: {
     analytics: true, // Optional - defaults to your Cloud configuration
   },
-  themeMode: "light",
+  themeMode: "dark",
   themeVariables: {
     "--w3m-color-mix": "#00BB7F",
     "--w3m-color-mix-strength": 40,
@@ -53,7 +53,7 @@ if (rootEl) {
     <StrictMode>
       <WagmiProvider config={wagmiAdapter.wagmiConfig}>
         <QueryClientProvider client={queryClient}>
-          <TamaguiProvider config={config}>
+          <TamaguiProvider config={config} defaultTheme="dark_neon">
             <App />
           </TamaguiProvider>
         </QueryClientProvider>

--- a/apps/demo-od-streaming/tamagui.config.ts
+++ b/apps/demo-od-streaming/tamagui.config.ts
@@ -1,10 +1,8 @@
-import { createTamagui, createFont } from 'tamagui';
-import { tokens, themes as baseThemes } from '@tamagui/themes';
-import { createAnimations } from '@tamagui/animations-react-native';
-import { createThemeBuilder } from '@tamagui/theme-builder';
+import { createTamagui, createFont, TamaguiInternalConfig } from "tamagui";
+import { tokens } from "@tamagui/themes";
 
 const orbitronFont = createFont({
-  family: 'Orbitron, sans-serif',
+  family: "Orbitron, sans-serif",
   size: {
     1: 12,
     2: 14,
@@ -30,54 +28,63 @@ const orbitronFont = createFont({
     10: 56,
   },
   weight: {
-    4: '400',
-    5: '500',
-    7: '700',
+    4: "400",
+    5: "500",
+    7: "700",
   },
   letterSpacing: {
     4: 0,
   },
 });
 
-const themeBuilder = createThemeBuilder().addThemes({
-  dark_neon: {
-    parent: 'dark',
-    theme: {
-      background: '#0d0d0d',
-      backgroundHover: '#1a1a1a',
-      backgroundPress: '#262626',
-      color: '#e0e0e0',
-      colorHover: '#ffffff',
-      colorPress: '#ffffff',
-      borderColor: '#a855f7',
-      borderColorHover: '#c084fc',
-      shadowColor: '#a855f7',
-      shadowColorHover: '#c084fc',
-      placeholderColor: '#7e7e7e',
+const customTheme: any = {
+  dark: {
+    background: "#0d0d0d",
+    backgroundHover: "#1a1a1a",
+    backgroundPress: "#262626",
+    color: "#e0e0e0",
+    colorHover: "#ffffff",
+    colorPress: "#ffffff",
+    borderColor: "#a855f7",
+    borderColorHover: "#c084fc",
+    shadowColor: "#a855f7",
+    shadowColorHover: "#c084fc",
+    placeholderColor: "#7e7e7e",
+  },
+};
+
+const config: TamaguiInternalConfig = createTamagui({
+  tokens,
+  themes: {
+    dark: {
+      background: "#0d0d0d",
+      backgroundHover: "#1a1a1a",
+      backgroundPress: "#262626",
+      color: "#e0e0e0",
+      colorHover: "#ffffff",
+      colorPress: "#ffffff",
+      borderColor: "#a855f7",
+      borderColorHover: "#c084fc",
+      shadowColor: "#a855f7",
+      shadowColorHover: "#c084fc",
+      placeholderColor: "#7e7e7e",
     },
   },
-});
-
-const themes = { ...baseThemes, ...themeBuilder.build() } as const;
-
-const config = createTamagui({
-  tokens,
-  themes,
-  defaultTheme: 'dark_neon',
+  defaultTheme: "dark",
   fonts: {
     heading: orbitronFont,
     body: orbitronFont,
   },
-  animations: createAnimations({
-    fast: 'ease-in 150ms',
-    medium: 'ease-out 300ms',
-    slow: 'ease-out 450ms'
-  })
+  // animations: createAnimations({
+  //   fast: "ease-in 150ms",
+  //   medium: "ease-out 300ms",
+  //   slow: "ease-out 450ms",
+  // }),
 });
 
 export type AppConfig = typeof config;
 
-declare module 'tamagui' {
+declare module "tamagui" {
   interface TamaguiCustomConfig extends AppConfig {}
 }
 

--- a/apps/demo-od-streaming/tamagui.config.ts
+++ b/apps/demo-od-streaming/tamagui.config.ts
@@ -1,6 +1,7 @@
 import { createTamagui, createFont } from 'tamagui';
 import { tokens, themes as baseThemes } from '@tamagui/themes';
 import { createAnimations } from '@tamagui/animations-react-native';
+import { createThemeBuilder } from '@tamagui/theme-builder';
 
 const orbitronFont = createFont({
   family: 'Orbitron, sans-serif',
@@ -38,23 +39,26 @@ const orbitronFont = createFont({
   },
 });
 
-const themes = {
-  ...baseThemes,
+const themeBuilder = createThemeBuilder().addThemes({
   dark_neon: {
-    ...baseThemes.dark,
-    background: '#0d0d0d',
-    backgroundHover: '#1a1a1a',
-    backgroundPress: '#262626',
-    color: '#e0e0e0',
-    colorHover: '#ffffff',
-    colorPress: '#ffffff',
-    borderColor: '#a855f7',
-    borderColorHover: '#c084fc',
-    shadowColor: '#a855f7',
-    shadowColorHover: '#c084fc',
-    placeholderColor: '#7e7e7e',
+    parent: 'dark',
+    theme: {
+      background: '#0d0d0d',
+      backgroundHover: '#1a1a1a',
+      backgroundPress: '#262626',
+      color: '#e0e0e0',
+      colorHover: '#ffffff',
+      colorPress: '#ffffff',
+      borderColor: '#a855f7',
+      borderColorHover: '#c084fc',
+      shadowColor: '#a855f7',
+      shadowColorHover: '#c084fc',
+      placeholderColor: '#7e7e7e',
+    },
   },
-};
+});
+
+const themes = { ...baseThemes, ...themeBuilder.build() } as const;
 
 const config = createTamagui({
   tokens,

--- a/apps/demo-od-streaming/tamagui.config.ts
+++ b/apps/demo-od-streaming/tamagui.config.ts
@@ -1,11 +1,69 @@
-import { createTamagui } from 'tamagui';
-import { tokens, themes } from '@tamagui/themes';
+import { createTamagui, createFont } from 'tamagui';
+import { tokens, themes as baseThemes } from '@tamagui/themes';
 import { createAnimations } from '@tamagui/animations-react-native';
+
+const orbitronFont = createFont({
+  family: 'Orbitron, sans-serif',
+  size: {
+    1: 12,
+    2: 14,
+    3: 16,
+    4: 18,
+    5: 20,
+    6: 24,
+    7: 28,
+    8: 32,
+    9: 36,
+    10: 48,
+  },
+  lineHeight: {
+    1: 16,
+    2: 20,
+    3: 22,
+    4: 24,
+    5: 28,
+    6: 32,
+    7: 36,
+    8: 40,
+    9: 44,
+    10: 56,
+  },
+  weight: {
+    4: '400',
+    5: '500',
+    7: '700',
+  },
+  letterSpacing: {
+    4: 0,
+  },
+});
+
+const themes = {
+  ...baseThemes,
+  dark_neon: {
+    ...baseThemes.dark,
+    background: '#0d0d0d',
+    backgroundHover: '#1a1a1a',
+    backgroundPress: '#262626',
+    color: '#e0e0e0',
+    colorHover: '#ffffff',
+    colorPress: '#ffffff',
+    borderColor: '#a855f7',
+    borderColorHover: '#c084fc',
+    shadowColor: '#a855f7',
+    shadowColorHover: '#c084fc',
+    placeholderColor: '#7e7e7e',
+  },
+};
 
 const config = createTamagui({
   tokens,
   themes,
-  defaultTheme: 'light',
+  defaultTheme: 'dark_neon',
+  fonts: {
+    heading: orbitronFont,
+    body: orbitronFont,
+  },
   animations: createAnimations({
     fast: 'ease-in 150ms',
     medium: 'ease-out 300ms',

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "@vitejs/plugin-react": "^5.0.1",
     "path": "^0.12.7",
     "vite": "^7.1.3"
+  },
+  "resolutions": {
+    "tamagui": "1.132.21"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tamagui: 1.132.21
+
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tamagui/animations-react-native':
         specifier: 1.132.21
         version: 1.132.21(react-dom@18.3.1(react@18.3.1))(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
+      '@tamagui/theme-builder':
+        specifier: ^1.132.21
+        version: 1.132.21(react-dom@18.3.1(react@18.3.1))(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
       '@tamagui/themes':
         specifier: 1.132.21
         version: 1.132.21(react-dom@18.3.1(react@18.3.1))(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)


### PR DESCRIPTION
## Summary
- add Orbitron-powered `dark_neon` Tamagui theme with neon accents
- load Orbitron font and default the app to the new theme
- refactor player and app components to use theme tokens and glowing button styles

## Testing
- `pnpm -w turbo run lint` *(fails: no lint, workspace ok)*
- `pnpm -w turbo run typecheck` *(fails: subscription-sdk missing tsconfig)*
- `pnpm --filter demo-od-streaming lint`
- `pnpm --filter demo-od-streaming typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68ac1209e6c48329b0ba5e4585609fab