### PR TITLE
feat: redesign video gallery main page

### DIFF
--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -10,32 +10,51 @@ function renderVideo(video: Video, onSelect: (v: Video) => void) {
       key={video.id}
       onPress={() => onSelect(video)}
       borderRadius="$6"
-      padding={10}
+      padding={0}
       overflow="hidden"
-      height="100px"
+      width={200}
+      height={140}
       borderWidth={2}
       borderColor="$borderColor"
-      // animation="fast"
+      elevation={"$1"}
       hoverStyle={{ backgroundColor: "$backgroundHover" }}
       pressStyle={{ backgroundColor: "$backgroundPress" }}
+      style={{ boxShadow: "0 0 8px rgba(168,85,247,0.3)" }}
     >
-      <Image source={{ uri: video.thumbnail }} width={160} height={90} />
+      <YStack width="100%" height="100%">
+        <YStack position="relative" flex={1}>
+          <Image
+            source={{ uri: video.thumbnail }}
+            width="100%"
+            height="100%"
+            resizeMode="cover"
+          />
+          <Text
+            position="absolute"
+            bottom={4}
+            left={4}
+            paddingHorizontal={4}
+            borderRadius={4}
+            backgroundColor="$background"
+            color="$color"
+          >
+            {video.price} G$
+          </Text>
+        </YStack>
+        <YStack padding={6}>
+          <Text color="$color" fontSize="$3">
+            {video.title}
+          </Text>
+        </YStack>
+      </YStack>
     </Button>
   );
 }
 
 function ConnectSection() {
   return (
-    <YStack
-      gap="$4"
-      alignItems="center"
-      justifyContent="center"
-      theme="dark_neon"
-      // animation="medium"
-    >
+    <YStack flex={1} alignItems="center" justifyContent="center">
       <Text color="$color">Connect your wallet to view videos</Text>
-      {/* AppKit provides the connect button as a web component */}
-      <appkit-button />
     </YStack>
   );
 }
@@ -45,8 +64,6 @@ function VideoGallery({ onSelect }: { onSelect: (v: Video) => void }) {
     <XStack
       flexWrap="wrap"
       gap="$4"
-
-      // animation="medium"
     >
       {mockVideos.map((v) => renderVideo(v, onSelect))}
     </XStack>
@@ -73,29 +90,82 @@ function VideoPage({ video, onBack }: { video: Video; onBack: () => void }) {
   );
 }
 
+function GalleryTabs({
+  tab,
+  setTab,
+}: {
+  tab: string;
+  setTab: (t: string) => void;
+}) {
+  const tabs = ["Trending", "New", "Live", "4x"];
+  return (
+    <XStack gap="$4" marginBottom="$4">
+      {tabs.map((t) => (
+        <Button
+          key={t}
+          onPress={() => setTab(t)}
+          borderRadius="$6"
+          borderWidth={1}
+          borderColor={tab === t ? "$borderColor" : "transparent"}
+          backgroundColor="$background"
+          hoverStyle={{ backgroundColor: "$backgroundHover" }}
+          pressStyle={{ backgroundColor: "$backgroundPress" }}
+        >
+          <Text color="$color">{t}</Text>
+        </Button>
+      ))}
+    </XStack>
+  );
+}
+
+function Sidebar() {
+  return (
+    <YStack
+      width={80}
+      padding="$4"
+      borderRightWidth={1}
+      borderColor="$borderColor"
+      alignItems="center"
+      gap="$4"
+    >
+      <appkit-button />
+      <Button
+        disabled
+        borderRadius="$6"
+        borderWidth={1}
+        borderColor="$borderColor"
+        backgroundColor="$background"
+      >
+        <Text color="$color">Usage</Text>
+      </Button>
+    </YStack>
+  );
+}
+
 export default function App() {
   const { isConnected } = useAccount();
   const [selectedVideo, setSelectedVideo] = useState<Video | null>(null);
+  const [tab, setTab] = useState("Trending");
   return (
-    <YStack
-      flex={1}
-      padding="$4"
-      alignItems="center"
-      justifyContent="center"
-      width={1200}
-    >
-      {isConnected ? (
-        selectedVideo ? (
-          <VideoPage
-            video={selectedVideo}
-            onBack={() => setSelectedVideo(null)}
-          />
+    <XStack flex={1} width="100%" height="100vh">
+      <Sidebar />
+      <YStack flex={1} padding="$4" gap="$4">
+        {isConnected ? (
+          selectedVideo ? (
+            <VideoPage
+              video={selectedVideo}
+              onBack={() => setSelectedVideo(null)}
+            />
+          ) : (
+            <>
+              <GalleryTabs tab={tab} setTab={setTab} />
+              <VideoGallery onSelect={setSelectedVideo} />
+            </>
+          )
         ) : (
-          <VideoGallery onSelect={setSelectedVideo} />
-        )
-      ) : (
-        <ConnectSection />
-      )}
-    </YStack>
+          <ConnectSection />
+        )}
+      </YStack>
+    </XStack>
   );
 }

--- a/apps/demo-od-streaming/src/App.tsx
+++ b/apps/demo-od-streaming/src/App.tsx
@@ -61,10 +61,7 @@ function ConnectSection() {
 
 function VideoGallery({ onSelect }: { onSelect: (v: Video) => void }) {
   return (
-    <XStack
-      flexWrap="wrap"
-      gap="$4"
-    >
+    <XStack flexWrap="wrap" gap="$4">
       {mockVideos.map((v) => renderVideo(v, onSelect))}
     </XStack>
   );
@@ -72,7 +69,7 @@ function VideoGallery({ onSelect }: { onSelect: (v: Video) => void }) {
 
 function VideoPage({ video, onBack }: { video: Video; onBack: () => void }) {
   return (
-    <YStack gap="$4" alignItems="center" width="100%">
+    <YStack gap="$4" alignItems="center" width={800}>
       <VideoPlayer src={video.src} />
       <Button
         onPress={onBack}
@@ -121,7 +118,7 @@ function GalleryTabs({
 function Sidebar() {
   return (
     <YStack
-      width={80}
+      width={320}
       padding="$4"
       borderRightWidth={1}
       borderColor="$borderColor"

--- a/apps/demo-od-streaming/src/videos.ts
+++ b/apps/demo-od-streaming/src/videos.ts
@@ -2,10 +2,72 @@ export type Video = {
   id: number;
   thumbnail: string;
   src: string;
+  title: string;
+  price: string;
 };
 
 export const mockVideos: Video[] = [
-  { id: 1, thumbnail: "/assets/test1.jpg", src: "/assets/sample.mp4" },
-  { id: 2, thumbnail: "/assets/test1.jpg", src: "/assets/sample.mp4" },
-  { id: 3, thumbnail: "/assets/test1.jpg", src: "/assets/sample.mp4" },
+  {
+    id: 1,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Futuristic Cyberspace",
+    price: "3.40",
+  },
+  {
+    id: 2,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Cyberpunk Streets",
+    price: "5.60",
+  },
+  {
+    id: 3,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Virtual Reality Odyssey",
+    price: "2.60",
+  },
+  {
+    id: 4,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Neon Nights",
+    price: "3.10",
+  },
+  {
+    id: 5,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Midnight Menscape",
+    price: "4.10",
+  },
+  {
+    id: 6,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Dark Nights",
+    price: "1.90",
+  },
+  {
+    id: 7,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Neon Odyssey",
+    price: "5.60",
+  },
+  {
+    id: 8,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Neon Rovide",
+    price: "6.20",
+  },
+  {
+    id: 9,
+    thumbnail: "/assets/test1.jpg",
+    src: "/assets/sample.mp4",
+    title: "Addostrum",
+    price: "3.40",
+  },
 ];

--- a/packages/subscriptionSdk/tsconfig.json
+++ b/packages/subscriptionSdk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist"
+  }
+}
+


### PR DESCRIPTION
## Summary
- add sidebar with wallet connect and usage placeholder
- implement tabbed video gallery with neon card styling
- fix subscription sdk typecheck by adding tsconfig

## Testing
- `pnpm -w turbo run lint`
- `pnpm -w turbo run typecheck`
- `pnpm -w turbo run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac480285788329be87d6af1216b550